### PR TITLE
Removing android.widget.Adapter dependency from ItemLoader

### DIFF
--- a/library/src/main/java/org/lucasr/smoothie/ItemLoader.java
+++ b/library/src/main/java/org/lucasr/smoothie/ItemLoader.java
@@ -733,7 +733,7 @@ public abstract class ItemLoader<AnyAdapter, Params, Result> {
         private final boolean mFromMemory;
 
         public DisplayItemRunnable(ItemLoader<AnyAdapter, Params, Result> itemLoader,
-                                   ItemRequest<Params, Result> request, boolean fromMemory) {
+            ItemRequest<Params, Result> request, boolean fromMemory) {
             mItemLoader = itemLoader;
             mRequest = request;
             mFromMemory = fromMemory;

--- a/library/src/main/java/org/lucasr/smoothie/ItemManager.java
+++ b/library/src/main/java/org/lucasr/smoothie/ItemManager.java
@@ -28,7 +28,6 @@ import android.widget.Adapter;
 import android.widget.AdapterView;
 import android.widget.AdapterView.OnItemSelectedListener;
 import android.widget.ListAdapter;
-import android.widget.WrapperListAdapter;
 
 /**
  * <p>ItemManager ties the user interaction (scroll, touch,
@@ -56,7 +55,7 @@ public final class ItemManager {
 
     private ItemManaged mManaged;
 
-    private final ItemLoader<?, ?> mItemLoader;
+    private final ItemLoader<Adapter, ?, ?> mItemLoader;
     private final Handler mHandler;
 
     private final boolean mPreloadItemsEnabled;
@@ -67,7 +66,7 @@ public final class ItemManager {
     private boolean mPendingItemsUpdate;
     private boolean mFingerUp;
 
-    private ItemManager(ItemLoader<?, ?> itemLoader, boolean preloadItemsEnabled,
+    private ItemManager(ItemLoader<Adapter, ?, ?> itemLoader, boolean preloadItemsEnabled,
             int preloadItemsCount, int threadPoolSize) {
         mManaged = null;
 
@@ -285,7 +284,7 @@ public final class ItemManager {
         private static final int DEFAULT_PRELOAD_ITEMS_COUNT = 4;
         private static final int DEFAULT_THREAD_POOL_SIZE = 2;
 
-        private final ItemLoader<?, ?> mItemLoader;
+        private final ItemLoader<Adapter, ?, ?> mItemLoader;
 
         private boolean mPreloadItemsEnabled;
         private int mPreloadItemsCount;
@@ -294,7 +293,7 @@ public final class ItemManager {
         /**
          * @param itemLoader - Your {@link ItemLoader} subclass implementation.
          */
-        public Builder(ItemLoader<?, ?> itemLoader) {
+        public Builder(ItemLoader<Adapter, ?, ?> itemLoader) {
             mItemLoader = itemLoader;
 
             mPreloadItemsEnabled = DEFAULT_PRELOAD_ITEMS_ENABLED;

--- a/library/src/main/java/org/lucasr/smoothie/SimpleItemLoader.java
+++ b/library/src/main/java/org/lucasr/smoothie/SimpleItemLoader.java
@@ -17,7 +17,7 @@ import android.widget.Adapter;
  *
  * @author Lucas Rocha <lucasr@lucasr.org>
  */
-public abstract class SimpleItemLoader<Params, Result> extends ItemLoader<Params, Result> {
+public abstract class SimpleItemLoader<Params, Result> extends ItemLoader<Adapter, Params, Result> {
     @Override
     final public int getItemPartCount(Adapter adapter, int position) {
         return 1;


### PR DESCRIPTION
Using generics in the `ItemLoader` is possible to avoid the dependency from `android.widget.Adapter` and ease future generalisations that can use other type of adapters/target views (eg:  `RecyclerView`).
This has been possible because `ItemLoader` does not rely on any `android.widget.Adapter` behaviour, but uses that type only in the signature of some of its business methods.
